### PR TITLE
[ARCHIVES] Change archives attribute to be a file.

### DIFF
--- a/e2e/smoke/BUILD
+++ b/e2e/smoke/BUILD
@@ -5,6 +5,8 @@ Add a basic smoke-test target below.
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 # load("@rules_probe_rs//probe_rs:defs.bzl", "...")
 
+exports_files(["versions.json"])
+
 # Replace with a usage of your rule/macro
 filegroup(name = "empty")
 

--- a/e2e/smoke/MODULE.bazel
+++ b/e2e/smoke/MODULE.bazel
@@ -11,7 +11,7 @@ local_path_override(
 probe_rs = use_extension("@rules_probe_rs//probe_rs:extensions.bzl", "probe_rs")
 probe_rs.tools(
     name = "probe_rs",
-    version = "0.24.0",
     archives = ":versions.json",
+    version = "0.24.0",
 )
 use_repo(probe_rs, "probe_rs")

--- a/e2e/smoke/MODULE.bazel
+++ b/e2e/smoke/MODULE.bazel
@@ -12,5 +12,6 @@ probe_rs = use_extension("@rules_probe_rs//probe_rs:extensions.bzl", "probe_rs")
 probe_rs.tools(
     name = "probe_rs",
     version = "0.24.0",
+    archives = ":versions.json",
 )
 use_repo(probe_rs, "probe_rs")

--- a/e2e/smoke/versions.json
+++ b/e2e/smoke/versions.json
@@ -1,0 +1,54 @@
+{
+  "0.24.0": [
+    {
+      "name": "probe_rs_tools_x86_64_unknown_linux_gnu",
+      "url": "https://github.com/probe-rs/probe-rs/releases/download/v0.24.0/probe-rs-tools-x86_64-unknown-linux-gnu.tar.xz",
+      "sha256": "21e8d7df39fa0cdc9a0421e0ac2ac5ba81ec295ea11306f26846089f6fe975c0",
+      "strip_prefix": "probe-rs-tools-x86_64-unknown-linux-gnu",
+      "exec_compatible_with": [
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64"
+      ]
+    },
+    {
+      "name": "probe_rs_tools_aarch64_unknown_linux_gnu",
+      "url": "https://github.com/probe-rs/probe-rs/releases/download/v0.24.0/probe-rs-tools-aarch64-unknown-linux-gnu.tar.xz",
+      "sha256": "95d91ebe08868d5119a698e3268ff60a4d71d72afa26ab207d43c807c729c90a",
+      "strip_prefix": "probe-rs-tools-aarch64-unknown-linux-gnu",
+      "exec_compatible_with": [
+        "@platforms//os:linux",
+        "@platforms//cpu:arm64"
+      ]
+    },
+    {
+      "name": "probe_rs_tools_x86_64_apple_darwin",
+      "url": "https://github.com/probe-rs/probe-rs/releases/download/v0.24.0/probe-rs-tools-x86_64-apple-darwin.tar.xz",
+      "sha256": "0e35cc92ff34af1b1c72dd444e6ddd57c039ed31c2987e37578864211e843cf1",
+      "strip_prefix": "probe-rs-tools-x86_64-apple-darwin",
+      "exec_compatible_with": [
+        "@platforms//os:macos",
+        "@platforms//cpu:x86_64"
+      ]
+    },
+    {
+      "name": "probe_rs_tools_aarch64_apple_darwin",
+      "url": "https://github.com/probe-rs/probe-rs/releases/download/v0.24.0/probe-rs-tools-aarch64-apple-darwin.tar.xz",
+      "sha256": "7140d9c2c61f8712ba15887f74df0cb40a7b16728ec86d5f45cc93fe96a0a29a",
+      "strip_prefix": "probe-rs-tools-aarch64-apple-darwin",
+      "exec_compatible_with": [
+        "@platforms//os:macos",
+        "@platforms//cpu:arm64"
+      ]
+    },
+    {
+      "name": "probe_rs_tools_x86_64_pc_windows_msvc",
+      "url": "https://github.com/probe-rs/probe-rs/releases/download/v0.24.0/probe-rs-tools-x86_64-pc-windows-msvc.zip",
+      "sha256": "d195dfa3466a87906251e27d6d70a0105274faa28ebf90ffadad0bdd89b1ec77",
+      "strip_prefix": "probe-rs-tools-x86_64-pc-windows-msvc",
+      "exec_compatible_with": [
+        "@platforms//os:windows",
+        "@platforms//cpu:x86_64"
+      ]
+    }
+  ]
+}

--- a/examples/nrf52840/blinky/BUILD.bazel
+++ b/examples/nrf52840/blinky/BUILD.bazel
@@ -1,5 +1,5 @@
-load("@rules_rust//rust:defs.bzl", "rust_binary")
 load("@rules_probe_rs//probe_rs:defs.bzl", "probe_rs")
+load("@rules_rust//rust:defs.bzl", "rust_binary")
 
 platform(
     name = "nrf52840",


### PR DESCRIPTION
Archives is currently defined as a attr.string_list_dict which is a dictionary whos values are a list of strings.

The versions structure is a dictionary of version to lists of dictionaries.  There is no way to define this attribute structure in bazel, so instead take a json file which contains the archives.