### PR TITLE
Switched probe-rs to be resolved as a bazel host side executable and not a part of target resolution

### DIFF
--- a/probe_rs/BUILD.bazel
+++ b/probe_rs/BUILD.bazel
@@ -17,7 +17,7 @@ bzl_library(
     srcs = ["defs.bzl"],
     visibility = ["//visibility:public"],
     deps = [
-        "@bazel_skylib//rules:native_binary",
+        "//probe_rs/private:run",
     ],
 )
 

--- a/probe_rs/defs.bzl
+++ b/probe_rs/defs.bzl
@@ -1,6 +1,6 @@
 "Public API re-exports"
 
-load("@bazel_skylib//rules:native_binary.bzl", "native_binary")
+load("//probe_rs/private:run.bzl", "probe_rs_run")
 
 def _probe_rs_run(name, elf, chip, args = [], **kwargs):
     """Run probe-rs on the given ELF file.
@@ -13,11 +13,12 @@ def _probe_rs_run(name, elf, chip, args = [], **kwargs):
         **kwargs: Additional arguments to pass to native_binary.
     """
 
-    native_binary(
+    probe_rs_run(
         name = name,
-        src = "@probe_rs//:probe-rs",
-        data = [elf],
-        args = ["run", "--chip", chip, "$(locations {})".format(elf)] + args,
+        elf = elf,
+        chip = chip,
+        probe_rs = "@probe_rs//:probe-rs",
+        probe_rs_args = args,
         **kwargs
     )
 

--- a/probe_rs/defs.bzl
+++ b/probe_rs/defs.bzl
@@ -17,8 +17,6 @@ def _probe_rs_run(name, elf, chip, args = [], **kwargs):
         name = name,
         elf = elf,
         chip = chip,
-        # Resolve this label in the caller's repo mapping so bzlmod users can
-        # `use_repo(..., "probe_rs")` from their main workspace.
         probe_rs = "@probe_rs//:probe-rs",
         probe_rs_args = args,
         **kwargs

--- a/probe_rs/defs.bzl
+++ b/probe_rs/defs.bzl
@@ -10,13 +10,15 @@ def _probe_rs_run(name, elf, chip, args = [], **kwargs):
         elf: The ELF file to run probe-rs on.
         chip: probe-rs chip to use. Ex. "nRF52840_xxAA"
         args: Additional arguments to pass to probe-rs.
-        **kwargs: Additional arguments to pass to native_binary.
+        **kwargs: Additional arguments to pass to the underlying executable rule.
     """
 
     probe_rs_run(
         name = name,
         elf = elf,
         chip = chip,
+        # Resolve this label in the caller's repo mapping so bzlmod users can
+        # `use_repo(..., "probe_rs")` from their main workspace.
         probe_rs = "@probe_rs//:probe-rs",
         probe_rs_args = args,
         **kwargs

--- a/probe_rs/private/BUILD.bazel
+++ b/probe_rs/private/BUILD.bazel
@@ -7,6 +7,12 @@ bzl_library(
 )
 
 bzl_library(
+    name = "run",
+    srcs = ["run.bzl"],
+    visibility = ["//probe_rs:__subpackages__"],
+)
+
+bzl_library(
     name = "versions",
     srcs = ["versions.bzl"],
     visibility = ["//probe_rs:__subpackages__"],

--- a/probe_rs/private/run.bzl
+++ b/probe_rs/private/run.bzl
@@ -10,6 +10,7 @@ def _quote_batch(arg):
 
 def _probe_rs_run_impl(ctx):
     elf = ctx.file.elf
+    # probe-rs is a host tool even when the ELF was built for an embedded target.
     tool = ctx.executable.probe_rs
     is_windows = tool.basename.endswith(".exe")
     script_name = ctx.label.name + (".bat" if is_windows else ".sh")
@@ -17,6 +18,8 @@ def _probe_rs_run_impl(ctx):
 
     args = ["run", "--chip", ctx.attr.chip, elf.short_path] + ctx.attr.probe_rs_args
 
+    # Emit a tiny launcher so `bazel run` executes probe-rs from runfiles while
+    # still allowing the ELF input to stay in the target configuration.
     if is_windows:
         script = "\r\n".join([
             "@echo off",
@@ -35,6 +38,8 @@ def _probe_rs_run_impl(ctx):
 
     ctx.actions.write(launcher, script, is_executable = True)
 
+    # Keep both the ELF and the host tool in runfiles so the launcher can refer
+    # to them by short_path on every supported host platform.
     runfiles = ctx.runfiles(files = [elf, tool])
     runfiles = runfiles.merge(ctx.attr.elf[DefaultInfo].default_runfiles)
     runfiles = runfiles.merge(ctx.attr.probe_rs[DefaultInfo].default_runfiles)
@@ -53,6 +58,8 @@ probe_rs_run = rule(
         "probe_rs_args": attr.string_list(),
         "probe_rs": attr.label(
             executable = True,
+            # Resolve probe-rs for the execution platform rather than the ELF's
+            # target platform so cross-target flashing works correctly.
             cfg = "exec",
         ),
     },

--- a/probe_rs/private/run.bzl
+++ b/probe_rs/private/run.bzl
@@ -1,0 +1,59 @@
+"""Executable rule for running probe-rs against an ELF built for another platform."""
+
+def _quote_shell(arg):
+    return "'" + arg.replace("'", "'\"'\"'") + "'"
+
+def _quote_batch(arg):
+    escaped = arg.replace("^", "^^")
+    escaped = escaped.replace("\"", "\"\"")
+    return "\"" + escaped + "\""
+
+def _probe_rs_run_impl(ctx):
+    elf = ctx.file.elf
+    tool = ctx.executable.probe_rs
+    is_windows = tool.basename.endswith(".exe")
+    script_name = ctx.label.name + (".bat" if is_windows else ".sh")
+    launcher = ctx.actions.declare_file(script_name)
+
+    args = ["run", "--chip", ctx.attr.chip, elf.short_path] + ctx.attr.probe_rs_args
+
+    if is_windows:
+        script = "\r\n".join([
+            "@echo off",
+            "setlocal",
+            "{} {}".format(_quote_batch(tool.short_path), " ".join([_quote_batch(arg) for arg in args])),
+            "exit /b %ERRORLEVEL%",
+            "",
+        ])
+    else:
+        script = "\n".join([
+            "#!/usr/bin/env bash",
+            "set -euo pipefail",
+            "{} {}".format(_quote_shell(tool.short_path), " ".join([_quote_shell(arg) for arg in args])),
+            "",
+        ])
+
+    ctx.actions.write(launcher, script, is_executable = True)
+
+    runfiles = ctx.runfiles(files = [elf, tool])
+    runfiles = runfiles.merge(ctx.attr.elf[DefaultInfo].default_runfiles)
+    runfiles = runfiles.merge(ctx.attr.probe_rs[DefaultInfo].default_runfiles)
+
+    return [DefaultInfo(executable = launcher, runfiles = runfiles)]
+
+probe_rs_run = rule(
+    implementation = _probe_rs_run_impl,
+    executable = True,
+    attrs = {
+        "elf": attr.label(
+            mandatory = True,
+            allow_single_file = True,
+        ),
+        "chip": attr.string(mandatory = True),
+        "probe_rs_args": attr.string_list(),
+        "probe_rs": attr.label(
+            executable = True,
+            cfg = "exec",
+        ),
+    },
+)


### PR DESCRIPTION
Fixes issue where flash rules are not compatible with `@platforms//os:none` due to requiring a host to run `probe-rs`. Reason for this change is as follows:

I have networking library dependency used in an embedded firmware release. This library builds for both POSIX platforms and for smoltcp based embedded networking. To do so, it uses the `@platforms//os` platform to configure the build. Due to the probe-rs ruleset being a `native_binary` it requires a host to run on.

Realisically the ELF should be built for the embedded target (and be selectable with the `--platforms` key), while probe-rs should be selected for the host. The following steps were done to acomplish this:

- Adds a new executable rule in probe_rs/private/run.bzl
- Resolves probe-rs as something for bazel to execute and not produce
- Wraps the probe-rs executable in a small script for platform compatibility
- This should keep the existing probe_rs.run(name, elf, chip, args=...) API the same in probe_rs/defs.bzl

